### PR TITLE
DEV: Cria modulo do CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,14 +26,11 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     
-    - name: Create venv 
-      run: python3 -m venv .venv
-    
-    - name: Install package in venv
+    - name: Create venv & install package
       run: |
-        source .venv/bin/activate
         python -m pip install --upgrade pip
-        pip install -e .
+        pip install click
+        python -m ci install
 
     - name: Test command line app
       run: |
@@ -55,16 +52,12 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    
-    - name: Create venv 
-      run: python3 -m venv .venv
-    
-    - name: Install package in venv
-      if: runner.os == 'Windows'
+
+    - name: Create venv & install package
       run: |
-        .venv\Scripts\activate.bat
         python -m pip install --upgrade pip
-        pip install -e .
+        pip install click
+        python -m ci install
   
     - name: Test command line app
       run: |

--- a/README.md
+++ b/README.md
@@ -1,18 +1,21 @@
 # Jogos
 
-Primeiro, baixar o código com a comanda:
+Primeiro, baixar o código com a comanda e instalar o programa execute:
 
 ```
 git clone https://github.com/franklongford/jogos.git
+python -m ci install
 ```
+Entao, entre o ambiente virtual segundo seu OS. 
 
-Entao, instalar o programa:
+No MacOS ou Linux:
 ```
-python3 -m venv .venv
 source .venv/bin/activate
-pip install -e .
 ```
-
+ou no Windows:
+```
+.venv\Scripts\activate
+```
 Pra rodar, usa `roda` e entra o nome do jogo depois:
 ```
 roda [NOME]

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -1,0 +1,25 @@
+import click
+import os
+import sys
+from subprocess import check_call, run
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.command(name='install')
+def install():
+    check_call(
+        ["python3", "-m", "venv", ".venv"]
+    )
+    if "win" in sys.platform:
+        cmd = ["ci\install-windows.ps1"]
+    else:
+        cmd = ["bash", "ci/install-linux.sh"]
+    check_call(cmd)
+
+
+if __name__ == '__main__':
+    cli()

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -1,7 +1,9 @@
 import click
 import os
 import sys
-from subprocess import check_call, run
+from subprocess import check_call
+
+cwdir = os.path.dirname(__file__)
 
 
 @click.group()
@@ -15,9 +17,11 @@ def install():
         ["python3", "-m", "venv", ".venv"]
     )
     if "win" in sys.platform:
-        cmd = ["ci\install-windows.ps1"]
+        filename = os.path.join(cwdir, "install-windows.ps1")
+        cmd = ["powershell.exe", filename]
     else:
-        cmd = ["bash", "ci/install-linux.sh"]
+        filename = os.path.join(cwdir, "install-linux.sh")
+        cmd = ["bash", filename]
     check_call(cmd)
 
 

--- a/ci/install-linux.sh
+++ b/ci/install-linux.sh
@@ -1,0 +1,4 @@
+# /bin/bash
+
+source .venv/bin/activate
+pip install -e .

--- a/ci/install-windows.ps1
+++ b/ci/install-windows.ps1
@@ -1,0 +1,2 @@
+.venv\Script\activate.bat
+pip install -e .


### PR DESCRIPTION
Simplifica o método de instalação pra usar o modulo do `ci` com:
```
python -m ci install
```
Ambos Unix e Windows computadores sao apoiados.